### PR TITLE
Scoreboard drag container updates

### DIFF
--- a/src/renderer/components/Scoreboard.vue
+++ b/src/renderer/components/Scoreboard.vue
@@ -5,9 +5,9 @@
     v-model:w="position.w"
     v-model:h="position.h"
     :draggable="isDraggable"
-    :min-w="340"
-    :min-h="179"
-    :parent="true"
+    :minW="340"
+    :minH="179"
+    :parent="false"
     class="scoreboard"
     class-name-handle="scoreboard_handle"
     @drag-end="savePosition"
@@ -120,7 +120,7 @@
 </template>
 
 <script setup lang="ts">
-import { shallowRef, shallowReactive, reactive, onMounted, toRef, watch, computed } from 'vue'
+import { shallowRef, shallowReactive, reactive, onMounted, toRef, watch, computed, nextTick } from 'vue'
 import { useIntervalFn } from '@vueuse/core'
 import formatDuration from 'format-duration'
 import { getLocalStorage, setLocalStorage } from '@/useLocalStorage'
@@ -141,11 +141,15 @@ const isColumnVisibilityOpen = shallowRef(false)
 const title = shallowRef('GUESSES')
 const switchState = shallowRef(true)
 
-const position = shallowReactive({ x: 20, y: 50, w: 340, h: 390 })
+const defaultPosition = { x: 20, y: 50, w: 340, h: 390 }
+const position = shallowReactive(defaultPosition)
+
 onMounted(async () => {
+  await nextTick(); // Waits until the component is actually rendered, preventing potential null values
+
   Object.assign(
     position,
-    getLocalStorage('cg_scoreboard__position', { x: 20, y: 50, w: 340, h: 390 })
+    getLocalStorage('cg_scoreboard__position', defaultPosition)
   )
 })
 


### PR DESCRIPTION
- Corrected prop names for Vue3DraggableResizable
- Disabled Vue3DraggableResizable parent prop so scoreboard can be dragged freely (not the ideal fix but should be sufficient)
- Fixed async timing bug in onMounted that was causing null values of position.w and position.h
- Created defaultPosition variable to remove redundancy