### PR TITLE
Add 5k-options for chicken mode

### DIFF
--- a/src/main/Game.ts
+++ b/src/main/Game.ts
@@ -58,6 +58,8 @@ export default class Game {
   waterPlonkMode = "normal"
   invertScoring = false
   isGameOfChickenModeActivated = false
+  chickenModeSurvivesWith5k = false
+  chickenMode5kGivesPoints = false
 
 
 
@@ -76,6 +78,8 @@ export default class Game {
     this.pointGiftCommand = this.#settings.pointGiftCommand
     this.isClosestInWrongCountryModeActivated = this.#settings.isClosestInWrongCountryModeActivated
     this.isGameOfChickenModeActivated = this.#settings.isGameOfChickenModeActivated
+    this.chickenModeSurvivesWith5k = this.#settings.chickenModeSurvivesWith5k
+    this.chickenMode5kGivesPoints = this.#settings.chickenMode5kGivesPoints
     this.waterPlonkMode = this.#settings.waterPlonkMode
     this.invertScoring = this.#settings.invertScoring
 
@@ -218,11 +222,11 @@ export default class Game {
     const distance = haversineDistance(location, this.location!)
     var score = streamerGuess.timedOut ? 0 : calculateScore(distance, this.mapScale!, await getCountryCode(location) === this.#country, this.isClosestInWrongCountryModeActivated, this.waterPlonkMode, await isCoordsInLand(location), this.invertScoring)
     if(this.#db.getNumberOfGamesInRoundFromRoundId(this.#roundId!) !== 1 && this.isGameOfChickenModeActivated){
-      const didUserWinLastRound = this.#db.didUserWinLastRound('BROADCASTER', this.#roundId!, this.invertScoring)
+      const didUserWinLastRound = this.#db.didUserWinLastRound('BROADCASTER', this.#roundId!, this.invertScoring, this.chickenModeSurvivesWith5k)
       if(didUserWinLastRound){
-        score = 0
+        if (!(this.chickenMode5kGivesPoints && score == 5000))
+          score = 0
       }
-      
     }
     const streak = this.#db.getUserStreak(dbUser.id)
 
@@ -260,9 +264,10 @@ export default class Game {
     var score = calculateScore(distance, this.mapScale!, await getCountryCode(location) === this.#country, this.isClosestInWrongCountryModeActivated, this.waterPlonkMode, await isCoordsInLand(location), this.invertScoring)
     if(this.#db.getNumberOfGamesInRoundFromRoundId(this.#roundId!) !== 1 && this.isGameOfChickenModeActivated){
 
-      const didUserWinLastRound = this.#db.didUserWinLastRound(dbUser.id, this.#roundId!, this.invertScoring)
+      const didUserWinLastRound = this.#db.didUserWinLastRound(dbUser.id, this.#roundId!, this.invertScoring, this.chickenModeSurvivesWith5k)
       if(didUserWinLastRound){
-        score = 0
+        if (!(this.chickenMode5kGivesPoints && score == 5000))
+          score = 0
       }
     }
 

--- a/src/main/utils/useSettings.ts
+++ b/src/main/utils/useSettings.ts
@@ -54,6 +54,8 @@ const defaultSettings = {
   guessMarkersLimit: 30,
   isClosestInWrongCountryModeActivated: false,
   isGameOfChickenModeActivated: false,
+  chickenModeSurvivesWith5k: false,
+  chickenMode5kGivesPoints: false,
   waterPlonkMode: "normal",
   invertScoring: false,
   dartsTargetScore: 25000,

--- a/src/renderer/assets/styles.css
+++ b/src/renderer/assets/styles.css
@@ -73,6 +73,11 @@ hr {
   margin-bottom: 0.3rem;
 }
 
+.form__group__disabled
+{
+  color: #aaa
+}
+
 .form__group input,
 .form__group select {
   padding: 0;

--- a/src/renderer/assets/styles.css
+++ b/src/renderer/assets/styles.css
@@ -160,6 +160,10 @@ hr {
   outline: none;
 }
 
+.form__group input[type='checkbox'][disabled] {
+  opacity: 0.25;
+}
+
 .form__group input[type='checkbox']::before {
   content: '';
   width: 0.65rem;

--- a/src/renderer/assets/utilities.css
+++ b/src/renderer/assets/utilities.css
@@ -59,6 +59,9 @@
 .ml-05 {
   margin-left: 0.5rem;
 }
+.ml-10 {
+  margin-left: 1rem;
+}
 .mb-03 {
   margin-bottom: 0.3rem;
 }

--- a/src/renderer/components/Settings.vue
+++ b/src/renderer/components/Settings.vue
@@ -228,19 +228,19 @@
           <label
           class="form__group"
           :class="{ 'form__group__disabled' : settings.isGameOfChickenModeActivated === false}"
-          data-tip="5k bypasses loss of score"
+          data-tip="5k bypasses loss of score, meaning that the player closest without a 5k is the one penalized next round"
         >
           Getting a 5k bypasses the loss of score next round
-          <input v-model="settings.chickenModeSurvivesWith5k" type="checkbox"/>
+          <input v-model="settings.chickenModeSurvivesWith5k" type="checkbox" :disabled="!settings.isGameOfChickenModeActivated"/>
         </label>
 
         <label
           class="form__group"
           :class="{ 'form__group__disabled' : settings.isGameOfChickenModeActivated === false}"
-          data-tip="5k always gives points"
+          data-tip="5k always gives points, even if the player was closest last round"
         >
           Getting a 5k always give points
-          <input v-model="settings.chickenMode5kGivesPoints" type="checkbox"/>
+          <input v-model="settings.chickenMode5kGivesPoints" type="checkbox" :disabled="!settings.isGameOfChickenModeActivated"/>
         </label>
         </div>
     

--- a/src/renderer/components/Settings.vue
+++ b/src/renderer/components/Settings.vue
@@ -222,7 +222,27 @@
     >
       Game of Chicken (Closest Plonk gets 0 Points on next round)
       <input v-model="settings.isGameOfChickenModeActivated" type="checkbox" />
-    </label>        
+    </label>
+
+    <div class="ml-10">
+          <label
+          class="form__group"
+          :class="{ 'form__group__disabled' : settings.isGameOfChickenModeActivated === false}"
+          data-tip="5k bypasses loss of score"
+        >
+          Getting a 5k bypasses the loss of score next round
+          <input v-model="settings.chickenModeSurvivesWith5k" type="checkbox"/>
+        </label>
+
+        <label
+          class="form__group"
+          :class="{ 'form__group__disabled' : settings.isGameOfChickenModeActivated === false}"
+          data-tip="5k always gives points"
+        >
+          Getting a 5k always give points
+          <input v-model="settings.chickenMode5kGivesPoints" type="checkbox"/>
+        </label>
+        </div>
     
     <label
       class="form__group"


### PR DESCRIPTION
This commit adds two options for 5k mode
- Getting a 5k bypasses you for getting 0 points next round. This means that 0 points will be given to the first non-5k guess in rounds 1-4.
- Getting a 5k always gives you points even if you were first the previous round.

Both of these settings could be optionally enabled.