### PR TITLE
Add text on scoreboard that shows mode

### DIFF
--- a/src/main/Game.ts
+++ b/src/main/Game.ts
@@ -360,6 +360,31 @@ export default class Game {
     this.guessesOpen = false
   }
 
+  getModeHelp(): string {
+    var parts: string[] = []
+    if (this.#settings.invertScoring)
+    {
+      parts.push("Inverted scoring")
+    }
+
+    if (this.#settings.isClosestInWrongCountryModeActivated)
+    {
+      parts.push("Wrong country only")
+    }
+
+    if (this.#settings.isGameOfChickenModeActivated)
+    {
+      parts.push("Game of chicken 🐔")
+    }
+
+    if (this.#settings.isDartsMode)
+    {
+      const bustSign = this.#settings.isDartsModeBust ? '≤': ''
+      parts.push(`Darts 🎯(${bustSign}${this.#settings.dartsTargetScore})`)
+    }
+    return parts.join(", ")
+  }
+
   /**
    * Get the participants for the current round, sorted by who guessed first.
    */

--- a/src/main/GameHandler.ts
+++ b/src/main/GameHandler.ts
@@ -209,6 +209,7 @@ export default class GameHandler {
             this.#win.webContents.send(
               'game-started',
               this.#game.isMultiGuess,
+              this.#game.getModeHelp(),
               restoredGuesses,
               this.#game.getLocation()
             )

--- a/src/preload/chatguessrApi.ts
+++ b/src/preload/chatguessrApi.ts
@@ -62,6 +62,7 @@ export const chatguessrApi = {
   onGameStarted(
     callback: (
       isMultiGuess: boolean,
+      modeHelp: string,
       restoredGuesses: RoundResult[] | Player[],
       location: Location_
     ) => void

--- a/src/renderer/components/Frame.vue
+++ b/src/renderer/components/Frame.vue
@@ -6,6 +6,7 @@
         ref="scoreboard"
         :game-state
         :is-multi-guess
+        :mode-help
         :on-round-result-row-click
         :on-game-result-row-click
       />
@@ -106,6 +107,7 @@ const leaderboardVisible = shallowRef(false)
 
 const gameState = shallowRef<GameState>('none')
 const isMultiGuess = shallowRef<boolean>(false)
+const modeHelp = shallowRef<string>('')
 const guessMarkersLimit = shallowRef<number | null>(null)
 const currentLocation = shallowRef<LatLng | null>(null)
 const gameResultLocations = shallowRef<Location_[] | null>(null)
@@ -190,8 +192,9 @@ watch(
 )
 
 onBeforeUnmount(
-  chatguessrApi.onGameStarted((_isMultiGuess, restoredGuesses, location) => {
+  chatguessrApi.onGameStarted((_isMultiGuess, _modeHelp, restoredGuesses, location) => {
     isMultiGuess.value = _isMultiGuess
+    modeHelp.value = _modeHelp
     gameState.value = 'in-round'
 
     currentLocation.value = location

--- a/src/renderer/components/Scoreboard.vue
+++ b/src/renderer/components/Scoreboard.vue
@@ -56,6 +56,9 @@
     <div :class="['scoreboard-hint', { hidden: !isMultiGuess || gameState !== 'in-round' }]">
       Guess change allowed
     </div>
+    <div :class="['mode-hint', { hidden: props.modeHelp === '' || gameState !== 'in-round' }]">
+      {{props.modeHelp}}
+    </div>
 
     <input
       v-model.number="settings.scrollSpeed"
@@ -131,6 +134,7 @@ const { chatguessrApi } = window
 const props = defineProps<{
   gameState: GameState
   isMultiGuess: boolean
+  modeHelp: string
   onRoundResultRowClick: (index: number, position: LatLng) => void
   onGameResultRowClick: (row: GameResultDisplay) => void
 }>()
@@ -503,6 +507,11 @@ defineExpose({
 }
 
 .scoreboard-hint {
+  font-size: 11px;
+}
+
+.mode-hint {
+  padding-top: 4px;
   font-size: 11px;
 }
 


### PR DESCRIPTION
This commit adds a text on the scoreboard that shows the current mode that is being played (if different from normal chatguessr mode).

![bild](https://github.com/user-attachments/assets/a8e795d9-565c-4046-8dd1-7e001cd9893c)
