### PR TITLE
Add refined no-water-plonk

### DIFF
--- a/src/main/Game.ts
+++ b/src/main/Game.ts
@@ -260,7 +260,7 @@ export default class Game {
     }
 
     const distance = haversineDistance(location, this.location!)
-    var score = streamerGuess.timedOut ? 0 : calculateScore(distance, this.mapScale!, await getStreakCode(location) === this.#streakCode, this.isClosestInWrongCountryModeActivated, this.waterPlonkMode, await isCoordsInLand(location), this.invertScoring)
+    var score = streamerGuess.timedOut ? 0 : calculateScore(distance, this.mapScale!, await getStreakCode(location) === this.#streakCode, this.isClosestInWrongCountryModeActivated, this.waterPlonkMode, await isCoordsInLand(location, this.waterPlonkMode), this.invertScoring)
     if(this.#db.getNumberOfGamesInRoundFromRoundId(this.#roundId!) !== 1 && this.isGameOfChickenModeActivated){
       const didUserWinLastRound = this.#db.didUserWinLastRound('BROADCASTER', this.#roundId!, this.invertScoring, this.chickenModeSurvivesWith5k)
       if(didUserWinLastRound){
@@ -315,7 +315,7 @@ export default class Game {
     }
 
     const distance = haversineDistance(location, this.location!)
-    var score = calculateScore(distance, this.mapScale!, await getStreakCode(location) === this.#streakCode, this.isClosestInWrongCountryModeActivated, this.waterPlonkMode, await isCoordsInLand(location), this.invertScoring)
+    var score = calculateScore(distance, this.mapScale!, await getStreakCode(location) === this.#streakCode, this.isClosestInWrongCountryModeActivated, this.waterPlonkMode, await isCoordsInLand(location, this.waterPlonkMode), this.invertScoring)
     if(this.#db.getNumberOfGamesInRoundFromRoundId(this.#roundId!) !== 1 && this.isGameOfChickenModeActivated){
 
       const didUserWinLastRound = this.#db.didUserWinLastRound(dbUser.id, this.#roundId!, this.invertScoring, this.chickenModeSurvivesWith5k)
@@ -469,7 +469,7 @@ export default class Game {
       parts.push(`Darts 🎯(${bustSign}${this.#settings.dartsTargetScore})`)
     }
     if (this.#settings.waterPlonkMode !== "normal"){
-      if(this.#settings.waterPlonkMode === "illegal"){
+      if((this.#settings.waterPlonkMode === "illegal") || (this.#settings.waterPlonkMode === "illegal_refined")){
         parts.push("🌊❌")
       }
       if(this.#settings.waterPlonkMode === "mandatory"){

--- a/src/main/GameHandler.ts
+++ b/src/main/GameHandler.ts
@@ -919,6 +919,8 @@ export default class GameHandler {
       returnString += `oceanPlonk: mandatory | `
     if (settings.waterPlonkMode === "illegal")
       returnString += `oceanPlonk: illegal | `
+    if (settings.waterPlonkMode === "illegal_refined")
+      returnString += `waterPlonk: illegal | `
     if (settings.invertScoring)
       returnString += `invertScoring: on | `
     if (settings.isGameOfChickenModeActivated){

--- a/src/renderer/components/Settings.vue
+++ b/src/renderer/components/Settings.vue
@@ -328,7 +328,10 @@
     Ocean Plonks Illegal Mode
     <input type="radio" v-model="settings.waterPlonkMode" value="illegal" />
   </label>
-
+  <label class="form__group" data-tip="0 Points for Plonks in any bodies of water (based on OSM-data)">
+    Water plonks illegal (Experimental)
+    <input type="radio" v-model="settings.waterPlonkMode" value="illegal_refined" />
+  </label>
 
   </div>
 


### PR DESCRIPTION
This PR adds another waterplonk mode where we try to prohibit waterplonking even further by looking at OSM-data and seeing if the latidude+longitude pair is registered as being within water.

I left a console.log() in order to trouble-shoot what water was found. 