### PR TITLE
Add keyboard shortcuts for some buttons on the in-game-screen

### DIFF
--- a/src/renderer/components/Frame.vue
+++ b/src/renderer/components/Frame.vue
@@ -28,19 +28,19 @@
   <div class="cg-menu">
     <button
       :class="['cg-button', twitchConnectionState.state]"
-      title="Settings"
+      title="Settings (Shortcut: S)"
       @click="settingsVisible = true"
     >
       <IconGear />
     </button>
 
-    <button class="cg-button" title="Show/Hide Leaderboard" @click="leaderboardVisible = true">
+    <button class="cg-button" title="Show/Hide Leaderboard (Shortcut: L)" @click="leaderboardVisible = true">
       <IconLeaderboard />
     </button>
 
     <button
       class="cg-button"
-      title="Show/Hide timer"
+      title="Show/Hide timer (Shortcut: T)"
       :hidden="gameState === 'none'"
       @click="widgetVisibility.timerVisible = !widgetVisibility.timerVisible"
     >
@@ -50,7 +50,7 @@
 
     <button
       class="cg-button"
-      title="Show/Hide Scoreboard"
+      title="Show/Hide Scoreboard (Shortcut: H)"
       :hidden="gameState === 'none'"
       @click="widgetVisibility.scoreboardAndGgInterfaceVisible = !widgetVisibility.scoreboardAndGgInterfaceVisible"
     >
@@ -219,6 +219,33 @@ watch(
   },
   { immediate: true }
 )
+
+// Keyboard shortcuts
+// Note: These shortcuts are not sent to the game, so make sure to not override any shortcuts that are also used in the game.
+// Some notable examples are 'Spacebar' that is used in game to guess, or 'R' that is used to reset camera when playing moving/no move.
+const shortcutActions = {
+  'KeyS': () => { settingsVisible.value = !settingsVisible.value; }, // Toggle leaderboard
+  'KeyT': () => { widgetVisibility.timerVisible = !widgetVisibility.timerVisible; }, // Toggle timer
+  'KeyL': () => { leaderboardVisible.value = !leaderboardVisible.value; }, // Toggle leaderboard
+  'KeyH': () => { widgetVisibility.scoreboardAndGgInterfaceVisible = !widgetVisibility.scoreboardAndGgInterfaceVisible; },
+};
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  const action = shortcutActions[event.code];
+  if (action) {
+    event.preventDefault(); // Prevent the key event from propagating to the game
+    event.stopPropagation();
+    action();
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeyDown);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleKeyDown);
+});
 
 onBeforeUnmount(
   chatguessrApi.onGameStarted((_isMultiGuess, _isBRMode, _modeHelp, restoredGuesses, location) => {


### PR DESCRIPTION
I did not find a way to add keyboard shortcuts for things in game, such as toggling Terrain etc. But this approach works for things that are chatguessr Vue elements.

We could consider adding more shortcuts for things like:
- Open and close guesses (not sure what a good key here is)
- Guess scrolling maybe?

However, this felt like a good starting point!