### PR TITLE
Add CLAUDE.md with codebase guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev          # typecheck + start Electron app
+npm run typecheck    # run both typecheck:node and typecheck:web
+npm run lint         # ESLint with auto-fix
+npm run format       # Prettier formatting
+npm run test         # run Vitest tests
+npm run package      # build distributable
+```
+
+Run a single test file:
+```bash
+npx vitest run src/main/utils/gameHelper.test.ts
+```
+
+Requires a `.env` file — copy from `.env.example` and fill in the Supabase and socket server values.
+
+## Architecture
+
+This is a customized fork of ChatGuessr — an Electron app that injects a Vue 3 UI overlay into the GeoGuessr website, adding Twitch chat integration, multiplayer coordination via socket.io, and custom game modes.
+
+### Electron Process Boundaries
+
+**Main process** (`src/main/`): All game logic lives here. `GameHandler.ts` is the core orchestrator — it handles Twitch chat commands, communicates with the socket server, manages round/game state, and writes to SQLite via `Database.ts`. `useSettings.ts` manages 60+ user-configurable options persisted via electron-store.
+
+**Preload** (`src/preload/chatguessrApi.ts`): IPC bridge — exposes ~20 handlers to the renderer. All renderer↔main communication goes through this API.
+
+**Renderer** (`src/renderer/`): Vue 3 app injected into GeoGuessr's page. `rendererApi.ts` handles incoming IPC events and updates reactive state. Components in `src/renderer/components/` render the overlay UI (scoreboard, settings, timer). `src/renderer/mods/` contains game mode plugins that manipulate the GeoGuessr DOM/map.
+
+**Auth window** (`src/auth/`): Separate Electron window for Twitch OAuth flow via Supabase.
+
+### Key Files
+
+- `src/main/GameHandler.ts` — central game loop, Twitch command parsing, round management
+- `src/main/utils/useSettings.ts` — all configurable settings with defaults
+- `src/main/utils/gameHelper.ts` — coordinate/scoring math utilities (well-tested)
+- `src/main/utils/Database.ts` — SQLite abstraction for player stats and game history
+- `src/types.d.ts` — shared types: `Player`, `Location`, `RoundResult`, `GameResult`, etc.
+- `forge.config.ts` — Electron Forge + Vite build config (5 entry points: main, preload, renderer, auth_preload, auth_impl)
+
+### TypeScript Config Split
+
+- `tsconfig.node.json` — strict config for main process code
+- `tsconfig.web.json` — Vue/renderer config; path alias `@/*` → `src/renderer/*`
+
+### Code Style
+
+Prettier: single quotes, no semicolons, 100-char line width, no trailing commas. ESLint enforces Vue 3 + TypeScript rules.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ Be aware that it is in constant development. Releases should be stable, but if y
 
 Want to support the project? Go to <a href="https://chatguessr.com">the official ChatGuessr.com website</a>. You can find a dono link at the bottom.
 
-## Platform Support
-
-Windows only. Mac builds are currently not working.
-
 ---
 
 ## Game Modes

--- a/README.md
+++ b/README.md
@@ -5,67 +5,169 @@
 
 ## Info
 
-This is a customized Chatguessr Version. It is extending the main App version 3.0.3 by some fun modes, additional settings and advanced customizability.
+This is a customized ChatGuessr version, extending the main app (v3.0.3) with additional game modes, scoring modifiers, visual mods, and advanced settings. It is created with the support and input from the amazing ChatGuessr community on Twitch. <3
 
-Be aware that it is in constant development at the moment. Releases should be stable, but if you want to be sure, get the official ChatGuessr from <a href="https://chatguessr.com">the ChatGuessr.com website</a>
-
-It is created with the support and input from the amazing ChatGuessr Community on Twitch. <3
+Be aware that it is in constant development. Releases should be stable, but if you want the official version, get it from <a href="https://chatguessr.com">the ChatGuessr.com website</a>.
 
 ## Support
 
-Do you want to support the project? Go to <a href="https://chatguessr.com">the official ChatGuessr.com website</a>. You can find a dono link at the bottom.
+Want to support the project? Go to <a href="https://chatguessr.com">the official ChatGuessr.com website</a>. You can find a dono link at the bottom.
 
 ## Platform Support
 
-Only Windows right now. Mac build process is currently not working. Sorry about that. Trying to look into that soon.
+Windows only. Mac builds are currently not working.
 
-## Differences
+---
 
-### Mode Settings
+## Game Modes
 
-- Chicken Mode:
-Closest guess doesn't get any any points next round. So last round is free.
+### Game of Chicken 🐔
+The winner of the previous round scores 0 points in the next round — unless they 5k. Last round is always free.
 
-Additional Chicken Modes: 
+Options:
+- **5k avoids chicken** — scoring 5000 points saves you from the chicken penalty
+- **Chicken can 5k** — a 5k during your chicken round still gives you full points
 
-Getting a 5k bypasses you for getting 0 points next round. This means that 0 points will be given to the first non-5k guess in rounds 1-4.
+### Wrong Country Only
+Guessing in the correct country gives you 0 points. Only wrong-country plonks score. Borders are not always mapped perfectly, so guessing right on the border can be dangerous.
 
-Getting a 5k always gives you points even if you were first the previous round.
+### Inverted Scoring (Antipode)
+Scoring is reversed — the further your plonk is from the actual location, the more points you get. Closest to the antipode wins. Best played with difficult maps like Pain and Suffering or Random Pan and Zoom World.
 
-- Wrong Country only mode:
-If you plonk in the right Country you get 0 points. Be aware that Borders are not always mapped 100% right. Guessing right on the border can be dangerous. Do you dare to plonk one of your 50/50? Which side of the right country are you plonking?
+### Exclusive Mode
+Only the player with the closest guess scores points each round. Everyone else gets 0.
 
-- Invert scoring:
-You know where it is? Plonk the antipode. Furthest Plonk wins. Best played with difficult Maps like Pain and Suffering or Random Pan and Zoom World.
+### Countdown / Countup
+Guesses must follow a sequence based on the country name length:
 
-- Make Waterplonks Mandatory/Illegal:
-Tired of the Water Hedges? Tired of always plonking on Land? Switch it up. Mandatory Waterplonks means only plonking in international Waters. Coast does not count. (Hint: use OpenStreetMap)
+- **Countdown** — each round you must plonk in a country with *fewer* letters than your previous round. Start with a long country name. Example: United Kingdom (13) → Afghanistan (11) → Thailand (8) → Myanmar (7) → China (5)
+- **Countup** — each round you must plonk in a country with *more* letters than your previous round. Start with a short country name. Example: Iran (4) → Malta (5) → Greece (6) → Myanmar (7) → United Kingdom (13)
 
-- Countdown/-up:
+Players who break the sequence are disqualified for that round.
 
-Countdown mode: The current round you guess has to have less letters than the previous, so plonking in a country with a lot of letters in the first round would be best. For example: UnitedKingdom (13) -> Afghanistan (11) -> Thailand (8) -> Myanmar (7) -> China (5).
+### Alphabetical Mode
+Guesses must be in alphabetical order by country name across rounds:
 
-Countup mode: The current round you guess has to have more letters than the previous, so plonking in a country with a few letters in the first round would be best. For example: Iran (4) -> Malta (5) -> Greece (6) -> Myanmar (7) -> UnitedKingdom (13)
+- **A→Z** — each round's country must come later in the alphabet than the previous
+- **Z→A** — each round's country must come earlier in the alphabet than the previous
 
-### Game Settings
+### ABC Mode
+Each round must be guessed in a country whose name starts with the next allowed letter. The allowed letters are configurable (e.g. `ABCDE` means round 1 must start with A, round 2 with B, etc.).
 
-- Activate or deactivate every Type of Message.
-- Additional Commands: !randomplonkwater (in international Waters only), !mode (shows Game Mode)
-- !addpoints to gift Points (Nightbot or Stream Elements) to Viewers for winning Rounds or Games. Command can be customized.
+### Darts Mode
+Players compete to get as close as possible to a target score (default 25,000) — not necessarily the highest score.
 
-### Other
+Options:
+- **Target score** — configurable (default 25,000)
+- **Bust** — if enabled, exceeding the target score eliminates you for that round
 
-- Reduce Opacity when hovering over the Flag on Results Screen to be better able to read City Names.
-- Hide Info Box (the purple thing on top right with Map Name, Round & Score) and Map when hiding Scoreboard.
-- Fix Bug that causes repeating "Guesses are opened", "Round Started" when clicking "Play Again" after a game.
-- add custom Flags in the `\AppData\Roaming\ChatGuessr\flags` directory. If image file is called test.jpg command would be "!flag test". Allowed files are: .svg, .png, .jpg, .jpeg, .webp, .gif, .apng
-- add possibility to change Twitch messages to display different text.
-- fixed random plonk issue (no avatar, players who changed their name were able to double plonk)
-- exclude streamer data from !best commands
+### Battle Royale Mode
+Players get multiple guess attempts per round, with points deducted for reguesses.
+
+Options:
+- **Reguess limit** — max total guesses per round per player (default 3)
+- **Points subtracted per reguess** — deducted on each reguess attempt (default 0)
+
+### Random Plonk Only Mode
+Only `!randomplonk` commands are accepted. Manual guesses are rejected.
+
+---
+
+## Water Plonk Modes
+
+- **Mandatory** — all guesses must be in international waters (coast does not count). Tip: use OpenStreetMap to find water spots.
+- **Illegal** — all guesses must be on land. Water plonks are rejected.
+
+---
+
+## Scoring Modifiers
+
+### Multi-Guess
+Players can update their guess during the round. Streaks are calculated at round end based on the final country.
+
+### Wrong Country Penalty
+Deducts a configurable number of points from guesses that land in the wrong country.
+
+### Allow Negative Scores
+Scores can go below 0 instead of being capped at 0.
+
+### Random Multipliers
+Each round may receive a random score multiplier. Multiplier is applied to all player scores for that round. Two systems available: random weighted distribution, or "Multi Merchant" mode.
+
+---
+
+## Visual Mods
+
+These are toggled per-session from the game setup screen and do not affect scoring.
+
+### Satellite Mode
+Enables a satellite/aerial view for the guessing map with a configurable bounds limit (how much of the map is visible).
+
+### Blink Mode
+Hides the street view panorama and briefly reveals it at a configurable interval.
+
+Options:
+- **Time limit** — how long the panorama is shown (0.1–5 seconds, default 0.8s)
+- **Round delay** — delay before first reveal each round (0.1–5 seconds, default 1s)
+
+### No Car / No Compass (NCNC)
+A collection of visual filters and element removals, toggleable individually:
+
+| Option | Effect |
+|---|---|
+| No Car | Hides the car icon |
+| No Compass | Hides the compass UI |
+| Water | Applies a water/wave filter |
+| Scramble | Distorts the image |
+| Rescramble | Re-distorts on a timer (requires Scramble) |
+| Pixelate | Pixelates the view |
+| Greyscale | Converts to greyscale |
+| Sepia | Applies sepia tone |
+| Upside Down | Rotates the entire page 180° |
+| CRT | CRT monitor effect |
+| Toon | Cartoon/toon shader |
+
+---
+
+## Twitch Channel Point Rewards
+
+These are triggered by custom channel point redemptions. The reward IDs must be configured to match your channel.
+
+- **Disappointment Island** — forces the targeted viewer to plonk at Disappointment Island (-50.607°, 165.972°)
+- **Pay2Win** — forces the redeemer to plonk at the exact correct location (guaranteed 5k)
+- **Russian Roulette** — applies a hidden random penalty or effect to the redeemer
+
+---
+
+## Commands & Settings Differences
+
+### Additional Twitch Commands
+- `!randomplonk` / `!rp` — places a random guess (respects water plonk mode)
+- `!randomplonk [countrycode]` — random guess within a specific country (if enabled)
+- `!randomplonkwater` / `!taquitoplonk` — random guess in international waters
+- `!mode` — shows the currently active game mode
+- `!countrycode` — posts a link to country code list
+
+### Points Gifting
+Award bonus points to round or game winners via a bot command (e.g. Nightbot or StreamElements). The command and point amount are fully configurable.
+
+### Message Customization
+Every type of ChatGuessr Twitch message can be individually activated/deactivated and customized with different text.
+
+### Custom Flags
+Add custom flags by placing image files in `%AppData%\ChatGuessr\flags\`. Supported formats: `.svg`, `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.apng`. The filename becomes the flag command (e.g. `test.jpg` → `!flag test`).
+
+### Other Fixes & Improvements
+- Opacity reduction when hovering over flags on the results screen (to read city names behind them)
+- Info box and map are hidden together with the scoreboard when hidden
+- Fixed repeating "Guesses are opened" / "Round Started" messages when clicking Play Again
+- Fixed random plonk issues (no avatar, players who changed name could double-plonk)
+- Streamer data excluded from `!best` commands
+
+---
 
 ## License
 
 The ChatGuessr source is available under the [MIT License](./LICENSE).
 
 The Montserrat font is used under the [Open Font License](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL).
-


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to document the codebase for Claude Code sessions
- Covers build/test/lint/dev commands and how to run a single test
- Explains the Electron process boundary architecture (main, preload, renderer, auth)
- Lists key files and their roles
- Notes the TypeScript config split and Prettier/ESLint style conventions

https://claude.ai/code/session_01P9vU74tikhJoiawKqUfDgN

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9vU74tikhJoiawKqUfDgN)_